### PR TITLE
HTML-builder

### DIFF
--- a/01-read-file/index.js
+++ b/01-read-file/index.js
@@ -1,0 +1,12 @@
+import { createReadStream } from 'fs';
+import path from 'path';
+
+const filePath = path.resolve('./01-read-file/text.txt');
+
+const readStream = createReadStream(filePath, { encoding: 'utf-8' });
+
+readStream.on('data', (chunk) => process.stdout.write(chunk));
+
+readStream.on('error', (err) => {
+  console.error('Error reading file:', err.message);
+});

--- a/02-write-file/index.js
+++ b/02-write-file/index.js
@@ -1,0 +1,34 @@
+import { createWriteStream } from 'fs';
+import { resolve } from 'path';
+
+const FILE_NAME = 'file-to-write.txt';
+const filePath = resolve('./02-write-file', FILE_NAME);
+
+const writeStream = createWriteStream(filePath, { flags: 'w' });
+
+writeStream.on('error', (error) => {
+  console.error('Error writing to the file:', error.message);
+  throw new Error('FS operation failed');
+});
+
+console.log(
+  'Start typing to write to the file. Press Ctrl+C or type "exit" to quit.',
+);
+
+process.stdin.on('data', (data) => {
+  const input = data.toString().trim();
+
+  if (input.toLowerCase() === 'exit') {
+    console.log('Goodbye!');
+    writeStream.end();
+    process.exit();
+  }
+
+  writeStream.write(input + '\n');
+});
+
+process.on('SIGINT', () => {
+  console.log('\nGoodbye!');
+  writeStream.end();
+  process.exit();
+});

--- a/03-files-in-folder/index.js
+++ b/03-files-in-folder/index.js
@@ -1,0 +1,25 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+const folderPath = path.join('./03-files-in-folder', 'secret-folder');
+
+const displayFileInfo = async () => {
+  try {
+    const files = await fs.readdir(folderPath, { withFileTypes: true });
+
+    for (const file of files) {
+      if (file.isFile()) {
+        const filePath = path.join(folderPath, file.name);
+        const stats = await fs.stat(filePath);
+        const extname = path.extname(file.name).slice(1);
+        const size = (stats.size / 1024).toFixed(3);
+
+        console.log(`${file.name} - ${extname} - ${size}kb`);
+      }
+    }
+  } catch (error) {
+    console.error('Error reading directory:', error.message);
+  }
+};
+
+displayFileInfo();

--- a/04-copy-directory/index.js
+++ b/04-copy-directory/index.js
@@ -1,0 +1,63 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+const DIR_NAME = 'files';
+const COPY_DIR_NAME = 'files-copy';
+const directoryToCopy = path.resolve('./04-copy-directory', DIR_NAME);
+const destinationToCopy = path.resolve('./04-copy-directory', COPY_DIR_NAME);
+
+const copy = async () => {
+    try {
+        await fs.access(directoryToCopy);
+    } catch (error) {
+        throw new Error('FS operation failed: source directory does not exist');
+    }
+
+    try {
+        await fs.access(destinationToCopy);
+        await fs.rm(destinationToCopy, { recursive: true, force: true });
+    } catch (error) {
+        if (error.code !== 'ENOENT') {
+            throw new Error('FS operation failed: unexpected error during access check');
+        }
+    }
+
+    const files = await fs.readdir(directoryToCopy, { withFileTypes: true });
+
+    await fs.mkdir(destinationToCopy, { recursive: true });
+
+    await Promise.all(
+        files.map(async (file) => {
+            const srcFile = path.join(directoryToCopy, file.name);
+            const destFile = path.join(destinationToCopy, file.name);
+
+            if (file.isDirectory()) {
+                await copyDir(srcFile, destFile);
+            } else {
+                await fs.copyFile(srcFile, destFile);
+            }
+        })
+    );
+
+    console.log('Files copied successfully');
+};
+
+const copyDir = async (src, dest) => {
+    const files = await fs.readdir(src, { withFileTypes: true });
+    await fs.mkdir(dest, { recursive: true });
+
+    await Promise.all(
+        files.map(async (file) => {
+            const srcFile = path.join(src, file.name);
+            const destFile = path.join(dest, file.name);
+
+            if (file.isDirectory()) {
+                await copyDir(srcFile, destFile);
+            } else {
+                await fs.copyFile(srcFile, destFile);
+            }
+        })
+    );
+};
+
+await copy();

--- a/05-merge-styles/index.js
+++ b/05-merge-styles/index.js
@@ -1,0 +1,31 @@
+import { createWriteStream, promises as fsPromises } from 'fs';
+import { extname, join, resolve } from 'path';
+
+const stylesFolder = resolve('05-merge-styles', 'styles');
+const outputFolder = resolve('05-merge-styles', 'project-dist');
+const bundleFile = resolve(outputFolder, 'bundle.css');
+
+const isCSSFile = (fileName) => extname(fileName) === '.css';
+
+const buildCSSBundle = async () => {
+  try {
+    await fsPromises.mkdir(outputFolder, { recursive: true });
+    const files = await fsPromises.readdir(stylesFolder, { withFileTypes: true });
+    const writeStream = createWriteStream(bundleFile);
+
+    for (const file of files) {
+      if (file.isFile() && isCSSFile(file.name)) {
+        const filePath = join(stylesFolder, file.name);
+        const data = await fsPromises.readFile(filePath, 'utf-8');
+        writeStream.write(data + '\n');
+      }
+    }
+
+    writeStream.end();
+    console.log('Build complete: bundle.css created.');
+  } catch (err) {
+    console.error('Error during styles bundling:', err);
+  }
+};
+
+buildCSSBundle();

--- a/06-build-page/index.js
+++ b/06-build-page/index.js
@@ -1,0 +1,95 @@
+import fs from 'fs/promises';
+import { extname, resolve } from 'path';
+
+const projectDistPath = resolve('06-build-page', 'project-dist');
+const templatePath = resolve('06-build-page', 'template.html');
+const componentsPath = resolve('06-build-page', 'components');
+const stylesPath = resolve('06-build-page', 'styles');
+const assetsPath = resolve('06-build-page', 'assets');
+const outputHtmlPath = resolve(projectDistPath, 'index.html');
+const outputCssPath = resolve(projectDistPath, 'style.css');
+const outputAssetsPath = resolve(projectDistPath, 'assets');
+
+async function createDistFolder() {
+  try {
+    await fs.mkdir(projectDistPath, { recursive: true });
+  } catch (err) {
+    console.error('Error creating project-dist folder:', err);
+  }
+}
+
+async function buildHtml() {
+  try {
+    let template = await fs.readFile(templatePath, 'utf-8');
+    const tags = template.match(/{{\s*[\w]+\s*}}/g);
+
+    for (const tag of tags || []) {
+      const tagName = tag.replace(/{{\s*|\s*}}/g, '');
+      const componentPath = resolve(componentsPath, `${tagName}.html`);
+
+      try {
+        const componentContent = await fs.readFile(componentPath, 'utf-8');
+        template = template.replace(new RegExp(tag, 'g'), componentContent);
+      } catch (err) {
+        console.error(`Component ${tagName} not found`);
+      }
+    }
+
+    await fs.writeFile(outputHtmlPath, template);
+  } catch (err) {
+    console.error('Error building HTML:', err);
+  }
+}
+
+async function buildStyles() {
+  try {
+    const files = await fs.readdir(stylesPath, { withFileTypes: true });
+    const cssFiles = files.filter(file => file.isFile() && extname(file.name) === '.css');
+
+    let cssContent = '';
+    for (const file of cssFiles) {
+      const filePath = resolve(stylesPath, file.name);
+      const styleContent = await fs.readFile(filePath, 'utf-8');
+      cssContent += styleContent + '\n';
+    }
+
+    await fs.writeFile(outputCssPath, cssContent);
+  } catch (err) {
+    console.error('Error building CSS:', err);
+  }
+}
+
+async function copyAssets(src, dest) {
+  try {
+    await fs.mkdir(dest, { recursive: true });
+    const entries = await fs.readdir(src, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const srcPath = resolve(src, entry.name);
+      const destPath = resolve(dest, entry.name);
+
+      if (entry.isDirectory()) {
+        await copyAssets(srcPath, destPath);
+      } else {
+        await fs.copyFile(srcPath, destPath);
+      }
+    }
+  } catch (err) {
+    console.error('Error copying assets:', err);
+  }
+}
+
+async function buildPage() {
+  try {
+    await createDistFolder();
+    await buildHtml();
+    await buildStyles();
+    await copyAssets(assetsPath, outputAssetsPath);
+
+    console.log('Page successfully built!');
+  } catch (err) {
+    console.error('Error building the page:', err);
+  }
+}
+
+buildPage();

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "html-builder",
   "version": "1.0.0",
   "description": "html-builder task for RSSchool",
+  "type": "module",
   "scripts": {
     "lint": "eslint .",
     "format": "prettier --write .",


### PR DESCRIPTION
# HTML-builder
Task: [link](https://github.com/rolling-scopes-school/tasks/tree/master/stage1/tasks/html-builder)
Screenshot: -
Deploy: -
Done 15.01.2025 / deadline 21.01.2025
Score: 150 / 150

## Read file
- [x] Inside the folder `01-read-file`, there are 2 files, `index.js` and `text.txt`.
- [x] When executing the command `node 01-read-file` <u>in the root directory of the repository</u>, the contents of the file `text.txt` should be printed to the console.
- [x] Synchronous file reading methods should not be used in the code.
- [x] File reading should occur using **ReadStream**.

## Write file
- [x] Inside the `02-write-file` folder, there is 1 file `index.js`.
- [x] When executing the command `node 02-write-file` <u>in the root directory of the repository</u>, a text file is created in the `02-write-file` folder, and a prompt for text input is displayed in the console (the text of prompt is of your choice).
- [x] After entering text, the entered text should be written to the previously created file in the `02-write-file` directory. The process does not terminate and awaits new input.
- [x] After the next input, the initially created text file is appended with new text, and the process continues to wait for input.
- [x] When pressing the `ctrl + c` key combination or entering `exit` into the console, a farewell phrase is displayed (the text of farewell phrase is of your choice), and the process terminates.

## Files in folder
- [x] When executing the command `node 03-files-in-folder` <u>in the root directory of the repository</u>, information about files contained directly within `03-files-in-folder/secret-folder` should be displayed in the console.  
       The data should be presented in the format `<file name>-<file extension>-<file size>`.  
       Example: `example - txt - 128.369kb`.
      _Note: no rounding for file size is necessary; conversion to kB is optional!_

- [x] Information should only be displayed for files located in `03-files-in-folder/secret-folder`. The presence of information about directories is considered an error.

## Copy directory
- [x] After the function execution terminates, a `files-copy` folder is created, the contents of which are an exact copy of the original `files` folder.
- [x] When files are added/removed/modified in the `files` folder and the `node 04-copy-directory` is rerun, the contents of the `files-copy` folder are updated.
- [x] The use of `fsPromises.cp()` is prohibited.

## Merge styles
- [x] After the script execution terminates, a `bundle.css` file containing styles from all files in the `styles` folder should be located in the `project-dist` folder.
- [x] When styles files are added/removed/modified in the `styles` folder and the script is rerun, the `bundle.css` file is overwritten and contains the up-to-date styles.
- [x] Any files with extensions other than `css` or directories are ignored.
- [x] Styles in the `bundle.css` file created during the compilation process should not be corrupted.

## Build page
- [x] After the script execution terminates, the `project-dist` folder should be created.
- [x] The `project-dist` folder should contain files `index.html` and `style.css`.
- [x] The `project-dist` folder should contain an `assets` folder that is an exact copy of the `assets` folder in `06-build-page`.
- [x] The use of `fsPromises.cp()` is prohibited.
- [x] The `index.html` file should contain markup resulting from the replacement of template tags in the `template.html` file.
- [x] The `style.css` file should contain styles compiled from files in the `styles` folder.
- [x] When adding a component to the folder and the corresponding tag to the original `template.html` file, rerunning the script should update the `index.html` file in the `project-dist` folder. The `style.css` file and `assets` folder should also maintain an up-to-date state.
- [x] When writing two or more template tags consecutively in the `template.html` file, separated only by spaces without line breaks, there should be no code execution errors. For example, `{{about}} {{articles}}` should be interpreted as two <u>separate</u> components.
- [x] The original `template.html` file should not be modified during script execution.
- [x] Writing content to the template from any files except those with the `.html` extension is an error.